### PR TITLE
Remove liquidity mining campaign entity on cancelation

### DIFF
--- a/src/mappings/staking-rewards.ts
+++ b/src/mappings/staking-rewards.ts
@@ -158,14 +158,12 @@ export function handleDistributionCancelation(event: Canceled): void {
   // Try to fetch LMCampaign, default back to SSSCampagin
   let lmCampaign = LiquidityMiningCampaign.load(campaignId)
   if (lmCampaign) {
-    lmCampaign.initialized = false
-    lmCampaign.save()
+    store.remove("LiquidityMiningCampaign", campaignId)
     return
   }
   let sssCampaign = SingleSidedStakingCampaign.load(campaignId)
   if (sssCampaign) {
-    sssCampaign.initialized = false
-    sssCampaign.save()
+    store.remove("SingleSidedStakingCampaign", campaignId)
     return
   }
 


### PR DESCRIPTION
A cancellation for a campaign is currently being approved through DXvote, but with the current code, Swapr would still be showing it in the UI. This fix removes the canceled liquidity mining campaign entity from the store, fixing the issue.