### PR TITLE
fix: handler for distribution cancellation event

### DIFF
--- a/subgraph.arbitrum-one-old.yaml
+++ b/subgraph.arbitrum-one-old.yaml
@@ -103,7 +103,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)

--- a/subgraph.arbitrum-one.yaml
+++ b/subgraph.arbitrum-one.yaml
@@ -119,7 +119,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)

--- a/subgraph.arbitrum-rinkeby.yaml
+++ b/subgraph.arbitrum-rinkeby.yaml
@@ -119,7 +119,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -119,7 +119,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -119,7 +119,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)

--- a/subgraph.xdai.yaml
+++ b/subgraph.xdai.yaml
@@ -125,7 +125,7 @@ templates:
         - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
           handler: handleDistributionInitialization
         - event: Canceled()
-          handler: handleCancelation
+          handler: handleDistributionCancelation
         - event: Staked(indexed address,uint256)
           handler: handleDeposit
         - event: Withdrawn(indexed address,uint256)


### PR DESCRIPTION
# Summary

Fixes 

![image](https://user-images.githubusercontent.com/1926216/159246550-26252400-689a-4817-afdb-e9e484f8725b.png)

The handler name in `staking-rewards.ts` is `handleDistributionCancelation` and not `handleCancelation`
