### PR TITLE
feat: track unique daily interactions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -245,7 +245,7 @@ type Bundle @entity {
 
 # Daily unique users interactions
 type DailyUniqueAddressInteraction @entity {
-  id: ID! # timestamp rounded to current day by dividing by 86400
+  id: ID! # timestamp formatted as YYYY-MM-DD date string
 
   addresses: [Bytes!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -243,6 +243,17 @@ type Bundle @entity {
   nativeCurrencyPrice: BigDecimal! # price of native currency usd
 }
 
+# Daily unique users interactions
+type DailyUniqueInteraction @entity {
+  id: ID! # timestamp rounded to current day by dividing by 86400
+  date: Int!
+
+  addresses: [Bytes!]!
+  swaps: BigInt!
+  mints: BigInt!
+  burns: BigInt!
+}
+
 # Data accumulated and condensed into day stats for all of Swapr
 type SwaprDayData @entity {
   id: ID! # timestamp rounded to current day by dividing by 86400

--- a/schema.graphql
+++ b/schema.graphql
@@ -244,14 +244,10 @@ type Bundle @entity {
 }
 
 # Daily unique users interactions
-type DailyUniqueInteraction @entity {
+type DailyUniqueAddressInteraction @entity {
   id: ID! # timestamp rounded to current day by dividing by 86400
-  date: Int!
 
   addresses: [Bytes!]!
-  swaps: BigInt!
-  mints: BigInt!
-  burns: BigInt!
 }
 
 # Data accumulated and condensed into day stats for all of Swapr

--- a/src/mappings/dayUpdates.ts
+++ b/src/mappings/dayUpdates.ts
@@ -1,4 +1,4 @@
-import { DailyUniqueInteraction, PairHourData } from './../types/schema'
+import { DailyUniqueAddressInteraction, PairHourData } from './../types/schema'
 /* eslint-disable prefer-const */
 import { BigInt, BigDecimal, ethereum } from '@graphprotocol/graph-ts'
 import { Pair, Token, SwaprDayData, PairDayData, TokenDayData } from '../types/schema'
@@ -36,7 +36,10 @@ export function updatePairDayData(event: ethereum.Event): PairDayData {
   let timestamp = event.block.timestamp.toI32()
   let dayID = timestamp / 86400
   let dayStartTimestamp = dayID * 86400
-  let dayPairID = event.address.toHexString().concat('-').concat(BigInt.fromI32(dayID).toString())
+  let dayPairID = event.address
+    .toHexString()
+    .concat('-')
+    .concat(BigInt.fromI32(dayID).toString())
   let pair = Pair.load(event.address.toHexString())
 
   if (!pair) {
@@ -70,7 +73,10 @@ export function updatePairHourData(event: ethereum.Event): PairHourData {
   let timestamp = event.block.timestamp.toI32()
   let hourIndex = timestamp / 3600 // get unique hour within unix history
   let hourStartUnix = hourIndex * 3600 // want the rounded effect
-  let hourPairID = event.address.toHexString().concat('-').concat(BigInt.fromI32(hourIndex).toString())
+  let hourPairID = event.address
+    .toHexString()
+    .concat('-')
+    .concat(BigInt.fromI32(hourIndex).toString())
   let pair = Pair.load(event.address.toHexString())
 
   if (!pair) {
@@ -102,7 +108,10 @@ export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDa
   let timestamp = event.block.timestamp.toI32()
   let dayID = timestamp / 86400
   let dayStartTimestamp = dayID * 86400
-  let tokenDayID = token.id.toString().concat('-').concat(BigInt.fromI32(dayID).toString())
+  let tokenDayID = token.id
+    .toString()
+    .concat('-')
+    .concat(BigInt.fromI32(dayID).toString())
 
   let tokenDayData = TokenDayData.load(tokenDayID)
   if (tokenDayData === null) {
@@ -132,23 +141,27 @@ export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDa
   return tokenDayData as TokenDayData
 }
 
-export function updateUniqueDailyInteractions(event: ethereum.Event): DailyUniqueInteraction {
-  let timestamp = event.block.timestamp.toI32()
-  let dayID = timestamp / 86400
-  let dayStartTimestamp = dayID * 86400
-  let uniqueDailyInteractionsData = DailyUniqueInteraction.load(dayID.toString())
+export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqueAddressInteraction {
+  const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
+  const today = new Date(timestamp)
 
-  if (uniqueDailyInteractionsData === null) {
-    uniqueDailyInteractionsData = new DailyUniqueInteraction(dayID.toString())
-    uniqueDailyInteractionsData.date = dayStartTimestamp
+  const paddedMonth = (today.getUTCMonth() + 1).toString().padStart(2, '0')
+  const paddedDay = today
+    .getUTCDate()
+    .toString()
+    .padStart(2, '0')
 
-    uniqueDailyInteractionsData.addresses = []
-    uniqueDailyInteractionsData.mints = ZERO_BI
-    uniqueDailyInteractionsData.burns = ZERO_BI
-    uniqueDailyInteractionsData.swaps = ZERO_BI
+  const dayIdString = `${today.getUTCFullYear()}-${paddedMonth}-${paddedDay}`
+
+  let dailyUniqueAddressInteractionsData = DailyUniqueAddressInteraction.load(dayIdString)
+
+  if (dailyUniqueAddressInteractionsData === null) {
+    dailyUniqueAddressInteractionsData = new DailyUniqueAddressInteraction(dayIdString)
+
+    dailyUniqueAddressInteractionsData.addresses = []
   }
 
-  uniqueDailyInteractionsData.save()
+  dailyUniqueAddressInteractionsData.save()
 
-  return uniqueDailyInteractionsData as DailyUniqueInteraction
+  return dailyUniqueAddressInteractionsData as DailyUniqueAddressInteraction
 }

--- a/src/mappings/dayUpdates.ts
+++ b/src/mappings/dayUpdates.ts
@@ -1,4 +1,4 @@
-import { PairHourData } from './../types/schema'
+import { DailyUniqueInteraction, PairHourData } from './../types/schema'
 /* eslint-disable prefer-const */
 import { BigInt, BigDecimal, ethereum } from '@graphprotocol/graph-ts'
 import { Pair, Bundle, Token, SwaprFactory, SwaprDayData, PairDayData, TokenDayData } from '../types/schema'
@@ -129,4 +129,25 @@ export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDa
   // updateStoredPairs(tokenDayData as TokenDayData, dayPairID)
 
   return tokenDayData as TokenDayData
+}
+
+export function updateUniqueDailyInteractions(event: ethereum.Event): DailyUniqueInteraction {
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let uniqueDailyInteractionsData = DailyUniqueInteraction.load(dayID.toString())
+
+  if (uniqueDailyInteractionsData === null) {
+    uniqueDailyInteractionsData = new DailyUniqueInteraction(dayID.toString())
+    uniqueDailyInteractionsData.date = dayStartTimestamp
+
+    uniqueDailyInteractionsData.addresses = []
+    uniqueDailyInteractionsData.mints = ZERO_BI
+    uniqueDailyInteractionsData.burns = ZERO_BI
+    uniqueDailyInteractionsData.swaps = ZERO_BI
+  }
+
+  uniqueDailyInteractionsData.save()
+
+  return uniqueDailyInteractionsData as DailyUniqueInteraction
 }

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -9,7 +9,7 @@ import {
   fetchTokenSymbol,
   fetchTokenName,
   fetchTokenDecimals,
-  fetchTokenTotalSupply,
+  fetchTokenTotalSupply
 } from './helpers'
 import { getFactoryAddress, getLiquidityTrackingTokenAddresses } from '../commons/addresses'
 


### PR DESCRIPTION
Fixes #8 

Add a new `DailyUniqueInteraction` entity to track the unique daily `swaps`, `mints` and `burns` interactions.
If a user performs a `swap` action and he performs another `swap/mints/burn` on the same day it won't be counted again.

As mentioned in related issue #8, is this the best way to achieve this?

> This way we would store a "useless" array of addresses for each entity since it's used only temporarily as a check.
Could this be too heavy/unoptimized to store?