### PR TITLE
feat: add Arbitrum Görli

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/nicoelzer/swapr-subgraph",
   "license": "GPL-3.0-or-later",
   "scripts": {
+    "graph:auth": "npx graph auth https://api.thegraph.com/deploy/ -- ",
     "codegen:mainnet": "graph codegen subgraph.mainnet.yaml  --output-dir src/types/",
     "codegen:rinkeby": "graph codegen subgraph.rinkeby.yaml --output-dir src/types/",
     "codegen:xdai": "graph codegen subgraph.xdai.yaml --output-dir src/types/",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "codegen:arbitrum-one": "graph codegen subgraph.arbitrum-one-old.yaml --output-dir src/types/",
     "codegen:arbitrum-one-v2": "graph codegen subgraph.arbitrum-one.yaml --output-dir src/types/",
     "codegen:arbitrum-rinkeby": "graph codegen subgraph.arbitrum-rinkeby.yaml --output-dir src/types/",
+    "codegen:arbitrum-goerli": "graph codegen subgraph.arbitrum-goerli.yaml --output-dir src/types/",
     "build:mainnet": "graph build subgraph.mainnet.yaml",
     "build:rinkeby": "graph build subgraph.rinkeby.yaml",
     "build:xdai": "graph build subgraph.xdai.yaml",
     "build:arbitrum-one": "graph build subgraph.arbitrum-one-old.yaml",
     "build:arbitrum-one-v2": "graph build subgraph.arbitrum-one.yaml",
     "build:arbitrum-rinkeby": "graph build subgraph.arbitrum-rinkeby.yaml",
+    "build:arbitrum-goerli": "graph build subgraph.arbitrum-goerli.yaml",
     "create-local": "graph create nicoelzer/swapr --node http://127.0.0.1:8020",
     "deploy-local:rinkeby": "graph deploy nicoelzer/swapr subgraph.rinkeby.yaml --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
     "deploy-local:mainnet": "graph deploy nicoelzer/swapr subgraph.rinkeby.yaml --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
@@ -29,7 +31,8 @@
     "deploy:arbitrum-one": "graph deploy luzzif/swapr-arbitrum-one subgraph.arbitrum-one-old.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy:arbitrum-one-v2": "graph deploy luzzif/swapr-arbitrum-one-v2 subgraph.arbitrum-one.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
     "deploy:arbitrum-one-v3": "graph deploy luzzif/swapr-arbitrum-one-v3 subgraph.arbitrum-one.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
-    "deploy:arbitrum-rinkeby": "graph deploy luzzif/swapr-arbitrum-rinkeby-v2 subgraph.arbitrum-rinkeby.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug"
+    "deploy:arbitrum-rinkeby": "graph deploy luzzif/swapr-arbitrum-rinkeby-v2 subgraph.arbitrum-rinkeby.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug",
+    "deploy:arbitrum-goerli": "graph deploy dxgraphs/swapr-arbitrum-goerli subgraph.arbitrum-goerli.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/ --debug"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.32.0",

--- a/subgraph.arbitrum-goerli.yaml
+++ b/subgraph.arbitrum-goerli.yaml
@@ -1,0 +1,132 @@
+specVersion: 0.0.4
+description: Swapr is a decentralized protocol for automated token exchange on Ethereum.
+repository: https://github.com/nicoelzer/swapr-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Factory
+    network: arbitrum-goerli
+    source:
+      address: '0x64a0745EF9d3772d9739D9350873eD3703bE45eC'
+      abi: Factory
+      startBlock: 10495
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mappings/factory.ts
+      entities:
+        - Pair
+        - Token
+      abis:
+        - name: Factory
+          file: ./abis/factory.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+      eventHandlers:
+        - event: PairCreated(indexed address,indexed address,address,uint256)
+          handler: handleNewPair
+  - kind: ethereum/contract
+    name: StakingRewardsFactory
+    network: arbitrum-goerli
+    source:
+      address: '0x95Bf186929194099899139Ff79998cC147290F28'
+      abi: StakingRewardsFactory
+      startBlock: 10604
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mappings/staking-rewards.ts
+      entities:
+        - Distribution
+      abis:
+        - name: Factory
+          file: ./abis/factory.json
+        - name: StakingRewardsFactory
+          file: ./abis/staking-rewards-factory.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+      eventHandlers:
+        - event: DistributionCreated(address,address)
+          handler: handleDistributionCreation
+templates:
+  - kind: ethereum/contract
+    name: Pair
+    network: arbitrum-goerli
+    source:
+      abi: Pair
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mappings/core.ts
+      entities:
+        - Pair
+        - Token
+      abis:
+        - name: Pair
+          file: ./abis/pair.json
+        - name: Factory
+          file: ./abis/factory.json
+      eventHandlers:
+        - event: Mint(indexed address,uint256,uint256)
+          handler: handleMint
+        - event: Burn(indexed address,uint256,uint256,indexed address)
+          handler: handleBurn
+        - event: Swap(indexed address,uint256,uint256,uint256,uint256,indexed address)
+          handler: handleSwap
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+        - event: Sync(uint112,uint112)
+          handler: handleSync
+  - kind: ethereum/contract
+    name: Distribution
+    network: arbitrum-goerli
+    source:
+      abi: StakingRewardsDistribution
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/mappings/staking-rewards.ts
+      entities:
+        - Deposit
+        - Withdrawal
+        - Claim
+        - Recovery
+      abis:
+        - name: Factory
+          file: ./abis/factory.json
+        - name: StakingRewardsDistribution
+          file: ./abis/staking-rewards-distribution.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ERC20SymbolBytes
+          file: ./abis/ERC20SymbolBytes.json
+        - name: ERC20NameBytes
+          file: ./abis/ERC20NameBytes.json
+      eventHandlers:
+        - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
+          handler: handleDistributionInitialization
+        - event: Canceled()
+          handler: handleDistributionCancelation
+        - event: Staked(indexed address,uint256)
+          handler: handleDeposit
+        - event: Withdrawn(indexed address,uint256)
+          handler: handleWithdrawal
+        - event: Claimed(indexed address,uint256[])
+          handler: handleClaim
+        - event: Recovered(uint256[])
+          handler: handleRecovery
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransfer


### PR DESCRIPTION
# Summary

Adds Arbitrum Görli deployment and configuration. This doesn't work yet, waiting for The Graph to respond on the status:

```
Build completed: QmRJHoNE54whYxrdZX31RexjzPdEV1aLhXCj13y1wV8A5L

✖ Failed to deploy to Graph node https://api.thegraph.com/deploy/: network not supported by registrar: no network arbitrum-goerli found on chain ethereum
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```