### PR TITLE
track weekly and monthly unique interactions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -250,6 +250,15 @@ type DailyUniqueAddressInteraction @entity {
   addresses: [Bytes!]!
 }
 
+# Weekly unique users interactions
+type WeeklyUniqueAddressInteraction @entity {
+  id: ID! # timestamp formatted as YYYY-MM-DD date string
+  weekStart: String!
+  weekEnd: String!
+
+  addresses: [Bytes!]!
+}
+
 # Data accumulated and condensed into day stats for all of Swapr
 type SwaprDayData @entity {
   id: ID! # timestamp rounded to current day by dividing by 86400

--- a/schema.graphql
+++ b/schema.graphql
@@ -259,6 +259,13 @@ type WeeklyUniqueAddressInteraction @entity {
   addresses: [Bytes!]!
 }
 
+# Monthly unique users interactions
+type MonthlyUniqueAddressInteraction @entity {
+  id: ID! # timestamp formatted as YYYY-MM date string
+
+  addresses: [Bytes!]!
+}
+
 # Data accumulated and condensed into day stats for all of Swapr
 type SwaprDayData @entity {
   id: ID! # timestamp rounded to current day by dividing by 86400

--- a/schema.graphql
+++ b/schema.graphql
@@ -252,7 +252,7 @@ type DailyUniqueAddressInteraction @entity {
 
 # Weekly unique users interactions
 type WeeklyUniqueAddressInteraction @entity {
-  id: ID! # timestamp formatted as YYYY-MM-DD date string
+  id: ID! # timestamp formatted as YYYY-WeekNumber date string
   weekStart: String!
   weekEnd: String!
 

--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -17,9 +17,11 @@ import {
   ZERO_BD,
   BI_18,
   createLiquiditySnapshot,
-  addDailyUniqueAddressInteraction
+  addDailyUniqueAddressInteraction,
+  addWeeklyUniqueAddressInteraction
 } from './helpers'
 import { getBundle, getSwaprFactory } from './factory'
+import { updateWeeklyUniqueInteractions } from './uniqueInteractions'
 
 function isCompleteMint(mintId: string): boolean {
   let mintEvent = MintEvent.load(mintId)
@@ -355,7 +357,11 @@ export function handleMint(event: Mint): void {
   updateTokenDayData(token0 as Token, event)
   updateTokenDayData(token1 as Token, event)
 
+  // update unique daily mints
   addDailyUniqueAddressInteraction(event, mint.to)
+
+  // update unique weekly mints
+  addWeeklyUniqueAddressInteraction(event, mint.to)
 }
 
 export function handleBurn(event: Burn): void {
@@ -423,7 +429,11 @@ export function handleBurn(event: Burn): void {
   updateTokenDayData(token0 as Token, event)
   updateTokenDayData(token1 as Token, event)
 
+  // update unique daily burns
   addDailyUniqueAddressInteraction(event, burn.to)
+
+  // update unique weekly burns
+  addWeeklyUniqueAddressInteraction(event, burn.to)
 }
 
 export function handleSwap(event: Swap): void {
@@ -585,4 +595,7 @@ export function handleSwap(event: Swap): void {
 
   // update unique day swaps
   addDailyUniqueAddressInteraction(event, swap.from)
+
+  // update unique weekly swaps
+  addWeeklyUniqueAddressInteraction(event, swap.from)
 }

--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -18,10 +18,10 @@ import {
   BI_18,
   createLiquiditySnapshot,
   addDailyUniqueAddressInteraction,
-  addWeeklyUniqueAddressInteraction
+  addWeeklyUniqueAddressInteraction,
+  addMonthlyUniqueAddressInteraction
 } from './helpers'
 import { getBundle, getSwaprFactory } from './factory'
-import { updateWeeklyUniqueInteractions } from './uniqueInteractions'
 
 function isCompleteMint(mintId: string): boolean {
   let mintEvent = MintEvent.load(mintId)
@@ -362,6 +362,9 @@ export function handleMint(event: Mint): void {
 
   // update unique weekly mints
   addWeeklyUniqueAddressInteraction(event, mint.to)
+
+  // update unique monthly mints
+  addMonthlyUniqueAddressInteraction(event, mint.to)
 }
 
 export function handleBurn(event: Burn): void {
@@ -434,6 +437,9 @@ export function handleBurn(event: Burn): void {
 
   // update unique weekly burns
   addWeeklyUniqueAddressInteraction(event, burn.to)
+
+  // update unique monthly burns
+  addMonthlyUniqueAddressInteraction(event, burn.to)
 }
 
 export function handleSwap(event: Swap): void {
@@ -598,4 +604,7 @@ export function handleSwap(event: Swap): void {
 
   // update unique weekly swaps
   addWeeklyUniqueAddressInteraction(event, swap.from)
+
+  // update unique monthly swaps
+  addMonthlyUniqueAddressInteraction(event, swap.to)
 }

--- a/src/mappings/dayUpdates.ts
+++ b/src/mappings/dayUpdates.ts
@@ -1,4 +1,4 @@
-import { DailyUniqueAddressInteraction, PairHourData } from './../types/schema'
+import { PairHourData } from './../types/schema'
 /* eslint-disable prefer-const */
 import { BigInt, BigDecimal, ethereum } from '@graphprotocol/graph-ts'
 import { Pair, Token, SwaprDayData, PairDayData, TokenDayData } from '../types/schema'
@@ -139,29 +139,4 @@ export function updateTokenDayData(token: Token, event: ethereum.Event): TokenDa
   // updateStoredPairs(tokenDayData as TokenDayData, dayPairID)
 
   return tokenDayData as TokenDayData
-}
-
-export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqueAddressInteraction {
-  const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
-  const today = new Date(timestamp)
-
-  const paddedMonth = (today.getUTCMonth() + 1).toString().padStart(2, '0')
-  const paddedDay = today
-    .getUTCDate()
-    .toString()
-    .padStart(2, '0')
-
-  const dayIdString = `${today.getUTCFullYear()}-${paddedMonth}-${paddedDay}`
-
-  let dailyUniqueAddressInteractionsData = DailyUniqueAddressInteraction.load(dayIdString)
-
-  if (dailyUniqueAddressInteractionsData === null) {
-    dailyUniqueAddressInteractionsData = new DailyUniqueAddressInteraction(dayIdString)
-
-    dailyUniqueAddressInteractionsData.addresses = []
-  }
-
-  dailyUniqueAddressInteractionsData.save()
-
-  return dailyUniqueAddressInteractionsData as DailyUniqueAddressInteraction
 }

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -19,7 +19,7 @@ import {
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
 import { getFactoryAddress, getStakingRewardsFactoryAddress } from '../commons/addresses'
 import { getBundle } from './factory'
-import { updateDailyUniqueInteractions } from './uniqueInteractions'
+import { updateDailyUniqueInteractions, updateMonthlyUniqueInteractions } from './uniqueInteractions'
 import { updateWeeklyUniqueInteractions } from './uniqueInteractions'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
@@ -409,5 +409,21 @@ export function addWeeklyUniqueAddressInteraction(event: ethereum.Event, address
     ])
 
     weeklyUniqueAddressInteractionsData.save()
+  }
+}
+
+export function addMonthlyUniqueAddressInteraction(event: ethereum.Event, address: Bytes | null): void {
+  const monthlyUniqueAddressInteractionsData = updateMonthlyUniqueInteractions(event)
+
+  if (!address) {
+    return
+  }
+
+  if (!monthlyUniqueAddressInteractionsData.addresses.includes(address)) {
+    monthlyUniqueAddressInteractionsData.addresses = monthlyUniqueAddressInteractionsData.addresses.concat([
+      address as Bytes
+    ])
+
+    monthlyUniqueAddressInteractionsData.save()
   }
 }

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -19,8 +19,11 @@ import {
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
 import { getFactoryAddress, getStakingRewardsFactoryAddress } from '../commons/addresses'
 import { getBundle } from './factory'
-import { updateDailyUniqueInteractions, updateMonthlyUniqueInteractions } from './uniqueInteractions'
-import { updateWeeklyUniqueInteractions } from './uniqueInteractions'
+import {
+  updateDailyUniqueInteractions,
+  updateWeeklyUniqueInteractions,
+  updateMonthlyUniqueInteractions
+} from './uniqueInteractions'
 
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 
@@ -337,7 +340,7 @@ export function getSwaprStakingRewardsFactory(): SwaprStakingRewardsFactory {
  *
  * @param date
  */
-export function getWeekFromDate(date: Date): i32 {
+export function getWeekNumberFromDate(date: Date): i32 {
   const startDate = Date.UTC(date.getUTCFullYear(), 0, 1)
   const days = Math.floor(((date.getTime() - startDate) / 86400000) as f32)
   const weekNumber = Math.ceil((days / 7) as f32)

--- a/src/mappings/uniqueInteractions.ts
+++ b/src/mappings/uniqueInteractions.ts
@@ -1,6 +1,6 @@
 import { ethereum, BigInt } from '@graphprotocol/graph-ts'
 
-import { WeeklyUniqueAddressInteraction, DailyUniqueAddressInteraction } from '../types/schema'
+import { WeeklyUniqueAddressInteraction, DailyUniqueAddressInteraction, MonthlyUniqueAddressInteraction } from '../types/schema'
 import { getWeekFromDate, getDateFromWeek, formatDate } from './helpers'
 
 export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqueAddressInteraction {
@@ -47,4 +47,23 @@ export function updateWeeklyUniqueInteractions(event: ethereum.Event): WeeklyUni
   weeklyUniqueAddressInteractionsData.save()
 
   return weeklyUniqueAddressInteractionsData as WeeklyUniqueAddressInteraction
+}
+
+export function updateMonthlyUniqueInteractions(event: ethereum.Event): MonthlyUniqueAddressInteraction {
+  const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
+  const today = new Date(timestamp)
+
+  const monthIdString = formatDate(today).substring(0, 7)
+
+  let monthlyUniqueAddressInteractionsData = MonthlyUniqueAddressInteraction.load(monthIdString)
+
+  if (monthlyUniqueAddressInteractionsData === null) {
+    monthlyUniqueAddressInteractionsData = new MonthlyUniqueAddressInteraction(monthIdString)
+
+    monthlyUniqueAddressInteractionsData.addresses = []
+  }
+
+  monthlyUniqueAddressInteractionsData.save()
+
+  return monthlyUniqueAddressInteractionsData as MonthlyUniqueAddressInteraction
 }

--- a/src/mappings/uniqueInteractions.ts
+++ b/src/mappings/uniqueInteractions.ts
@@ -1,0 +1,50 @@
+import { ethereum, BigInt } from '@graphprotocol/graph-ts'
+
+import { WeeklyUniqueAddressInteraction, DailyUniqueAddressInteraction } from '../types/schema'
+import { getWeekFromDate, getDateFromWeek, formatDate } from './helpers'
+
+export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqueAddressInteraction {
+  const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
+  const today = new Date(timestamp)
+
+  const dayIdString = formatDate(today)
+
+  let dailyUniqueAddressInteractionsData = DailyUniqueAddressInteraction.load(dayIdString)
+
+  if (dailyUniqueAddressInteractionsData === null) {
+    dailyUniqueAddressInteractionsData = new DailyUniqueAddressInteraction(dayIdString)
+
+    dailyUniqueAddressInteractionsData.addresses = []
+  }
+
+  dailyUniqueAddressInteractionsData.save()
+
+  return dailyUniqueAddressInteractionsData as DailyUniqueAddressInteraction
+}
+
+export function updateWeeklyUniqueInteractions(event: ethereum.Event): WeeklyUniqueAddressInteraction {
+  const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
+  const today = new Date(timestamp)
+
+  const weekNumber = getWeekFromDate(today)
+  const weekIdString = `${today.getUTCFullYear()}-${weekNumber}`
+
+  let weeklyUniqueAddressInteractionsData = WeeklyUniqueAddressInteraction.load(weekIdString)
+
+  if (weeklyUniqueAddressInteractionsData === null) {
+    weeklyUniqueAddressInteractionsData = new WeeklyUniqueAddressInteraction(weekIdString)
+
+    const weekStartDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
+    const weekEndDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
+    weekEndDate.setUTCDate(weekEndDate.getUTCDate() + 6)
+
+    weeklyUniqueAddressInteractionsData.weekStart = formatDate(weekStartDate)
+    weeklyUniqueAddressInteractionsData.weekEnd = formatDate(weekEndDate)
+
+    weeklyUniqueAddressInteractionsData.addresses = []
+  }
+
+  weeklyUniqueAddressInteractionsData.save()
+
+  return weeklyUniqueAddressInteractionsData as WeeklyUniqueAddressInteraction
+}

--- a/src/mappings/uniqueInteractions.ts
+++ b/src/mappings/uniqueInteractions.ts
@@ -1,7 +1,11 @@
 import { ethereum, BigInt } from '@graphprotocol/graph-ts'
 
-import { WeeklyUniqueAddressInteraction, DailyUniqueAddressInteraction, MonthlyUniqueAddressInteraction } from '../types/schema'
-import { getWeekFromDate, getDateFromWeek, formatDate } from './helpers'
+import {
+  WeeklyUniqueAddressInteraction,
+  DailyUniqueAddressInteraction,
+  MonthlyUniqueAddressInteraction
+} from '../types/schema'
+import { getWeekNumberFromDate, getDateFromWeek, formatDate } from './helpers'
 
 export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqueAddressInteraction {
   const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
@@ -26,7 +30,7 @@ export function updateWeeklyUniqueInteractions(event: ethereum.Event): WeeklyUni
   const timestamp = event.block.timestamp.times(BigInt.fromString('1000')).toI64()
   const today = new Date(timestamp)
 
-  const weekNumber = getWeekFromDate(today)
+  const weekNumber = getWeekNumberFromDate(today)
   const weekIdString = `${today.getUTCFullYear()}-${weekNumber}`
 
   let weeklyUniqueAddressInteractionsData = WeeklyUniqueAddressInteraction.load(weekIdString)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,9 +1719,9 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
Related to #18 

These changes add the tracking of the weekly and monthly unique addresses interactions (`swaps`, `mints`, `burns`), like the daily interactions.

This PR adds two new entities to track the weekly and monthly data:
```
WeeklyUniqueAddressInteraction
MonthlyUniqueAddressInteraction
```

For the `WeeklyUniqueAddressInteraction` there are two additional fields `weekStart` and `weekEnd`, ready to use for the weeks dates. 

The subgraph with these changes is deployed and can be tested [here](https://thegraph.com/hosted-service/subgraph/guerrap/swaprxdai)