### PR TITLE
feat: add timestamps to daily, weekly and monthly entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -246,6 +246,7 @@ type Bundle @entity {
 # Daily unique users interactions
 type DailyUniqueAddressInteraction @entity {
   id: ID! # timestamp formatted as YYYY-MM-DD date string
+  timestamp: Int! # timestamp
 
   addresses: [Bytes!]!
 }
@@ -253,8 +254,8 @@ type DailyUniqueAddressInteraction @entity {
 # Weekly unique users interactions
 type WeeklyUniqueAddressInteraction @entity {
   id: ID! # timestamp formatted as YYYY-WeekNumber date string
-  weekStart: String!
-  weekEnd: String!
+  timestampStart: Int! # timestamp at the first day of the week
+  timestampEnd: Int! # timestamp at the last day of the week
 
   addresses: [Bytes!]!
 }
@@ -262,6 +263,7 @@ type WeeklyUniqueAddressInteraction @entity {
 # Monthly unique users interactions
 type MonthlyUniqueAddressInteraction @entity {
   id: ID! # timestamp formatted as YYYY-MM date string
+  timestamp: Int! # timestamp at the first day of the month
 
   addresses: [Bytes!]!
 }

--- a/src/mappings/uniqueInteractions.ts
+++ b/src/mappings/uniqueInteractions.ts
@@ -12,11 +12,13 @@ export function updateDailyUniqueInteractions(event: ethereum.Event): DailyUniqu
   const today = new Date(timestamp)
 
   const dayIdString = formatDate(today)
+  const startOfDayDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()))
 
   let dailyUniqueAddressInteractionsData = DailyUniqueAddressInteraction.load(dayIdString)
 
   if (dailyUniqueAddressInteractionsData === null) {
     dailyUniqueAddressInteractionsData = new DailyUniqueAddressInteraction(dayIdString)
+    dailyUniqueAddressInteractionsData.timestamp = (startOfDayDate.getTime() / 1000) as i32
 
     dailyUniqueAddressInteractionsData.addresses = []
   }
@@ -38,12 +40,12 @@ export function updateWeeklyUniqueInteractions(event: ethereum.Event): WeeklyUni
   if (weeklyUniqueAddressInteractionsData === null) {
     weeklyUniqueAddressInteractionsData = new WeeklyUniqueAddressInteraction(weekIdString)
 
-    const weekStartDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
-    const weekEndDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
-    weekEndDate.setUTCDate(weekEndDate.getUTCDate() + 6)
+    const startOfWeekDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
+    const endOfWeekDate = getDateFromWeek(today.getUTCFullYear(), weekNumber)
+    endOfWeekDate.setUTCDate(endOfWeekDate.getUTCDate() + 6)
 
-    weeklyUniqueAddressInteractionsData.weekStart = formatDate(weekStartDate)
-    weeklyUniqueAddressInteractionsData.weekEnd = formatDate(weekEndDate)
+    weeklyUniqueAddressInteractionsData.timestampStart = (startOfWeekDate.getTime() / 1000) as i32
+    weeklyUniqueAddressInteractionsData.timestampEnd = (endOfWeekDate.getTime() / 1000) as i32
 
     weeklyUniqueAddressInteractionsData.addresses = []
   }
@@ -58,11 +60,13 @@ export function updateMonthlyUniqueInteractions(event: ethereum.Event): MonthlyU
   const today = new Date(timestamp)
 
   const monthIdString = formatDate(today).substring(0, 7)
+  const startOfMonthDate = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1))
 
   let monthlyUniqueAddressInteractionsData = MonthlyUniqueAddressInteraction.load(monthIdString)
 
   if (monthlyUniqueAddressInteractionsData === null) {
     monthlyUniqueAddressInteractionsData = new MonthlyUniqueAddressInteraction(monthIdString)
+    monthlyUniqueAddressInteractionsData.timestamp = (startOfMonthDate.getTime() / 1000) as i32
 
     monthlyUniqueAddressInteractionsData.addresses = []
   }


### PR DESCRIPTION
Fixes #24 
Add numeric `timestamps` to `daily`, `weekly`, and `monthly` unique interactions entities for better filtering and sorting.