### PR TITLE
refactor: remove pair token price handler

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -493,23 +493,3 @@ type SingleSidedStakingCampaignPosition @entity {
   stakedAmount: BigDecimal!
   singleSidedStakingCampaign: SingleSidedStakingCampaign!
 }
-
-enum PairTokenPriceTimeframe {
-  ONE_MINUTE
-  FIVE_MINUTES
-  FIFTEEN_MINUTES
-  ONE_HOUR
-  TWELVE_HOURS
-}
-
-type PairTokenPrice @entity {
-  id: ID!
-  timeframe: PairTokenPriceTimeframe!
-  blockNumber: BigInt!
-  blockTimestamp: BigInt!
-  pair: Pair!
-  token0Price: BigDecimal!
-  token0Address: Bytes!
-  token1Price: BigDecimal!
-  token1Address: Bytes!
-}

--- a/src/mappings/core.ts
+++ b/src/mappings/core.ts
@@ -19,9 +19,7 @@ import {
   createLiquiditySnapshot,
   addDailyUniqueAddressInteraction,
   addWeeklyUniqueAddressInteraction,
-  addMonthlyUniqueAddressInteraction,
-  createPairTokenPrice,
-  PairTokenPriceTimeframe,
+  addMonthlyUniqueAddressInteraction
 } from './helpers'
 import { getBundle, getSwaprFactory } from './factory'
 
@@ -594,49 +592,6 @@ export function handleSwap(event: Swap): void {
 
   // update unique monthly swaps
   addMonthlyUniqueAddressInteraction(event, swap.to)
-}
-
-export function handlePairTokenPrice(block: ethereum.Block): void {
-  let pairContractAddress = dataSource.address()
-  let pair = Pair.load(pairContractAddress.toHexString())
-
-  if (!pair) {
-    return
-  }
-
-  const blockTimestampDate = new Date(block.timestamp.toI64() * 1000)
-  const blockTimestampMinutes = blockTimestampDate.getUTCMinutes()
-  const blockTimestampHours = blockTimestampDate.getUTCHours()
-
-  const id = [
-    pair.id,
-    blockTimestampDate.getUTCFullYear().toString(),
-    blockTimestampDate.getUTCMonth().toString(),
-    blockTimestampHours.toString(),
-    blockTimestampMinutes.toString()
-  ].join('-')
-
-  const fiveMinutes = 5
-  const fifteenMinutes = 15
-  const twelveHours = 12
-
-  createPairTokenPrice(id, block, pair, PairTokenPriceTimeframe.ONE_MINUTE)
-
-  if (blockTimestampMinutes % fiveMinutes === 0) {
-    createPairTokenPrice(id, block, pair, PairTokenPriceTimeframe.FIVE_MINUTES)
-  }
-
-  if (blockTimestampMinutes % fifteenMinutes === 0) {
-    createPairTokenPrice(id, block, pair, PairTokenPriceTimeframe.FIFTEEN_MINUTES)
-  }
-
-  if (blockTimestampMinutes === 0) {
-    createPairTokenPrice(id, block, pair, PairTokenPriceTimeframe.ONE_HOUR)
-  }
-
-  if (blockTimestampHours % twelveHours === 0 && blockTimestampMinutes === 0) {
-    createPairTokenPrice(id, block, pair, PairTokenPriceTimeframe.TWELVE_HOURS)
-  }
 }
 
 /**

--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -14,8 +14,7 @@ import {
   LiquidityMiningPositionSnapshot,
   SingleSidedStakingCampaign,
   SingleSidedStakingCampaignPosition,
-  SwaprStakingRewardsFactory,
-  PairTokenPrice
+  SwaprStakingRewardsFactory
 } from '../types/schema'
 import { Factory as FactoryContract } from '../types/templates/Pair/Factory'
 import { getFactoryAddress, getStakingRewardsFactoryAddress } from '../commons/addresses'
@@ -430,27 +429,4 @@ export function addMonthlyUniqueAddressInteraction(event: ethereum.Event, addres
 
     monthlyUniqueAddressInteractionsData.save()
   }
-}
-
-export abstract class PairTokenPriceTimeframe {
-  static ONE_MINUTE: string = 'ONE_MINUTE'
-  static FIVE_MINUTES: string = 'FIVE_MINUTES'
-  static FIFTEEN_MINUTES: string = 'FIFTEEN_MINUTES'
-  static ONE_HOUR: string = 'ONE_HOUR'
-  static TWELVE_HOURS: string = 'TWELVE_HOURS'
-}
-
-export function createPairTokenPrice(id: string, block: ethereum.Block, pair: Pair, timeframe: string): void {
-  let pairTokenPrice = new PairTokenPrice(id + '-' + timeframe)
-
-  pairTokenPrice.blockNumber = block.number
-  pairTokenPrice.blockTimestamp = block.timestamp
-  pairTokenPrice.pair = pair.id
-  pairTokenPrice.token0Price = pair.token0Price || ZERO_BD
-  pairTokenPrice.token1Price = pair.token1Price || ZERO_BD
-  pairTokenPrice.token0Address = Address.fromString(pair.token0 || ADDRESS_ZERO)
-  pairTokenPrice.token1Address = Address.fromString(pair.token1 || ADDRESS_ZERO)
-  pairTokenPrice.timeframe = timeframe
-
-  pairTokenPrice.save()
 }

--- a/subgraph.arbitrum-one-old.yaml
+++ b/subgraph.arbitrum-one-old.yaml
@@ -70,8 +70,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.arbitrum-one.yaml
+++ b/subgraph.arbitrum-one.yaml
@@ -80,8 +80,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.arbitrum-rinkeby.yaml
+++ b/subgraph.arbitrum-rinkeby.yaml
@@ -80,8 +80,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.goerli.yaml
+++ b/subgraph.goerli.yaml
@@ -80,8 +80,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -80,8 +80,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -80,8 +80,6 @@ templates:
           file: ./abis/pair.json
         - name: Factory
           file: ./abis/factory.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer

--- a/subgraph.xdai.yaml
+++ b/subgraph.xdai.yaml
@@ -88,8 +88,6 @@ templates:
           file: ./abis/ERC20SymbolBytes.json
         - name: ERC20NameBytes
           file: ./abis/ERC20NameBytes.json
-      blockHandlers:
-        - handler: handlePairTokenPrice
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer


### PR DESCRIPTION
Avoid tracking the pairs' prices by removing the `handlePairTokenPrice` block handler.
The prices will be tracked in the new subgraph https://github.com/dxgraphs/swapr-prices-subgraph.